### PR TITLE
Support for ambient mode

### DIFF
--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -28,6 +28,8 @@ spec:
     metadata:
       labels:
         app: emailservice
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -84,6 +86,8 @@ spec:
     metadata:
       labels:
         app: checkoutservice
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       containers:
@@ -153,6 +157,8 @@ spec:
     metadata:
       labels:
         app: recommendationservice
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -213,8 +219,8 @@ spec:
     metadata:
       labels:
         app: frontend
-      annotations:
-        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       containers:
@@ -313,6 +319,8 @@ spec:
     metadata:
       labels:
         app: paymentservice
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -369,6 +377,8 @@ spec:
     metadata:
       labels:
         app: productcatalogservice
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -427,6 +437,8 @@ spec:
     metadata:
       labels:
         app: cartservice
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -444,7 +456,7 @@ spec:
             memory: 64Mi
           limits:
             cpu: 300m
-            memory: 128Mi
+            memory: 256Mi
         readinessProbe:
           initialDelaySeconds: 15
           exec:
@@ -481,8 +493,8 @@ spec:
     metadata:
       labels:
         app: loadgenerator
-      annotations:
-        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -531,6 +543,8 @@ spec:
     metadata:
       labels:
         app: currencyservice
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5
@@ -588,6 +602,8 @@ spec:
     metadata:
       labels:
         app: shippingservice
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       containers:
@@ -646,6 +662,8 @@ spec:
     metadata:
       labels:
         app: redis-cart
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       containers:
       - name: redis
@@ -699,6 +717,8 @@ spec:
     metadata:
       labels:
         app: adservice
+        version: v1
+        istio.io/dataplane-mode: ambient
     spec:
       serviceAccountName: default
       terminationGracePeriodSeconds: 5

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -456,7 +456,7 @@ spec:
             memory: 64Mi
           limits:
             cpu: 300m
-            memory: 256Mi
+            memory: 128Mi
         readinessProbe:
           initialDelaySeconds: 15
           exec:

--- a/release/kubernetes-manifests.yaml
+++ b/release/kubernetes-manifests.yaml
@@ -456,7 +456,7 @@ spec:
             memory: 64Mi
           limits:
             cpu: 300m
-            memory: 128Mi
+            memory: 200Mi
         readinessProbe:
           initialDelaySeconds: 15
           exec:


### PR DESCRIPTION
### Background 
<!-- What was happening before this PR, and the problem(s) it solves -->

### Fixes 
<!-- Link the issue(s) this PR fixes-->

I have made k8s manifest correspond to ambient mode of Istio without sidecar

### Change Summary
<!-- Short summary of the changes submitted -->

### Additional Notes
<!-- Any remaining concerns -->

using memory of cartservice is exceeding 128Mi (OOM), so I set it from 128Mi to 200Mi

![Screenshot 2025-04-24 at 4 22 32](https://github.com/user-attachments/assets/48674afb-b570-4374-8006-ad9bf9c62541)





### Testing Procedure
<!-- If applicable, write how to test for reviewers-->

### Related PRs or Issues 
<!-- Dependent PRs, or any relevant linked issues -->
